### PR TITLE
Three small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ SRU client for Node.js and browser
 ### ES modules
 ```js
 import createSruClient from '@natlibfi/sru-client';
-const client = createSruClient({url: 'https://foo.bar'});
+const client = createSruClient({serverUrl: 'https://foo.bar'});
 
 client.searchRetrieve('foo')
   .on('record', xmlString => processRecord(xmlString))
@@ -16,7 +16,7 @@ client.searchRetrieve('foo')
 ### Node
 ```js
 const createSruClient = require('@natlibfi/sru-client').default;
-const client = createSruClient({url: 'https://foo.bar'});
+const client = createSruClient({serverUrl: 'https://foo.bar'});
 
 client.searchRetrieve('foo')
   .on('record', xmlString => processRecord(xmlString))

--- a/src/index.js
+++ b/src/index.js
@@ -87,7 +87,7 @@ export default function ({serverUrl, version, maximumRecords, recordSchema}) {
 						}
 
 						if (doc.getElementsByTagNameNS('http://www.loc.gov/zing/srw/', 'nextRecordPosition').length > 0) {
-							pump(Number(doc.getElementsByTagNameNS('http://www.loc.gov/zing/srw/', 'nextRecordPosition').textContent));
+							pump(Number(doc.getElementsByTagNameNS('http://www.loc.gov/zing/srw/', 'nextRecordPosition').item(0).textContent));
 						} else {
 							Emitter.emit('end');
 						}

--- a/src/index.js
+++ b/src/index.js
@@ -71,8 +71,8 @@ export default function ({serverUrl, version, maximumRecords, recordSchema}) {
 				const doc = new DOMParser().parseFromString(await response.text());
 
 				try {
-					if (Number(doc.getElementsByTagName('zs:numberOfRecords').item(0).textContent) > 0) {
-						const records = doc.getElementsByTagName('zs:record');
+					if (Number(doc.getElementsByTagNameNS('http://www.loc.gov/zing/srw/', 'numberOfRecords').item(0).textContent) > 0) {
+						const records = doc.getElementsByTagNameNS('http://www.loc.gov/zing/srw/', 'record');
 
 						for (let i = 0; i < records.length; i++) {
 							const record = records.item(i);
@@ -86,8 +86,8 @@ export default function ({serverUrl, version, maximumRecords, recordSchema}) {
 							}
 						}
 
-						if (doc.getElementsByTagName('zs:nextRecordPosition').length > 0) {
-							pump(Number(doc.getElementsByTagName('zs:nextRecordPosition').textContent));
+						if (doc.getElementsByTagNameNS('http://www.loc.gov/zing/srw/', 'nextRecordPosition').length > 0) {
+							pump(Number(doc.getElementsByTagNameNS('http://www.loc.gov/zing/srw/', 'nextRecordPosition').textContent));
 						} else {
 							Emitter.emit('end');
 						}


### PR DESCRIPTION
- The full namespace should be used since the prefix can vary
- The extraction of `nextRecordPosition` was missing `.item(0)`
- The readme examples used `url`, not `serverUrl`