### PR TITLE
Dependency update

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -109,21 +109,21 @@
 			}
 		},
 		"node_modules/@babel/core": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.5.tgz",
-			"integrity": "sha512-Cwc2XjUrG4ilcfOw4wBAK+enbdgwAcAJCfGUItPBKR7Mjw4aEfAFYrLxeRp4jWgtNIKn3n2AlBOfwwafl+42/g==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.23.6.tgz",
+			"integrity": "sha512-FxpRyGjrMJXh7X3wGLGhNDCRiwpWEF74sKjTLDJSG5Kyvow3QZaG0Adbqzi9ZrVjTWpsX+2cxWXD71NMg93kdw==",
 			"dev": true,
 			"dependencies": {
 				"@ampproject/remapping": "^2.2.0",
 				"@babel/code-frame": "^7.23.5",
-				"@babel/generator": "^7.23.5",
-				"@babel/helper-compilation-targets": "^7.22.15",
+				"@babel/generator": "^7.23.6",
+				"@babel/helper-compilation-targets": "^7.23.6",
 				"@babel/helper-module-transforms": "^7.23.3",
-				"@babel/helpers": "^7.23.5",
-				"@babel/parser": "^7.23.5",
+				"@babel/helpers": "^7.23.6",
+				"@babel/parser": "^7.23.6",
 				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.5",
-				"@babel/types": "^7.23.5",
+				"@babel/traverse": "^7.23.6",
+				"@babel/types": "^7.23.6",
 				"convert-source-map": "^2.0.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
@@ -157,12 +157,12 @@
 			}
 		},
 		"node_modules/@babel/generator": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.5.tgz",
-			"integrity": "sha512-BPssCHrBD+0YrxviOa3QzpqwhNIXKEtOa2jQrm4FlmkC2apYgRnQcmPWiGZDlGxiNtltnUFolMe8497Esry+jA==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.23.6.tgz",
+			"integrity": "sha512-qrSfCYxYQB5owCmGLbl8XRpX1ytXlpueOb0N0UmQwA073KZxejgQTzAmJezxvpwQD9uGtK2shHdi55QT+MbjIw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/types": "^7.23.5",
+				"@babel/types": "^7.23.6",
 				"@jridgewell/gen-mapping": "^0.3.2",
 				"@jridgewell/trace-mapping": "^0.3.17",
 				"jsesc": "^2.5.1"
@@ -196,14 +196,14 @@
 			}
 		},
 		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.22.15",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.22.15.tgz",
-			"integrity": "sha512-y6EEzULok0Qvz8yyLkCvVX+02ic+By2UdOhylwUOvOn9dvYc9mKICJuuU1n1XBI02YWsNsnrY1kc6DVbjcXbtw==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.23.6.tgz",
+			"integrity": "sha512-9JB548GZoQVmzrFgp8o7KxdgkTGm6xs9DW0o/Pim72UDjzr5ObUQ6ZzYPqA+g9OTS2bBQoctLJrky0RDCAWRgQ==",
 			"dev": true,
 			"dependencies": {
-				"@babel/compat-data": "^7.22.9",
-				"@babel/helper-validator-option": "^7.22.15",
-				"browserslist": "^4.21.9",
+				"@babel/compat-data": "^7.23.5",
+				"@babel/helper-validator-option": "^7.23.5",
+				"browserslist": "^4.22.2",
 				"lru-cache": "^5.1.1",
 				"semver": "^6.3.1"
 			},
@@ -477,14 +477,14 @@
 			}
 		},
 		"node_modules/@babel/helpers": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.5.tgz",
-			"integrity": "sha512-oO7us8FzTEsG3U6ag9MfdF1iA/7Z6dz+MtFhifZk8C8o453rGJFFWUP1t+ULM9TUIAzC9uxXEiXjOiVMyd7QPg==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.23.6.tgz",
+			"integrity": "sha512-wCfsbN4nBidDRhpDhvcKlzHWCTlgJYUUdSJfzXb2NuBssDSIjc3xcb+znA7l+zYsFljAcGM0aFkN40cR3lXiGA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/template": "^7.22.15",
-				"@babel/traverse": "^7.23.5",
-				"@babel/types": "^7.23.5"
+				"@babel/traverse": "^7.23.6",
+				"@babel/types": "^7.23.6"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -528,9 +528,9 @@
 			}
 		},
 		"node_modules/@babel/parser": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.5.tgz",
-			"integrity": "sha512-hOOqoiNXrmGdFbhgCzu6GiURxUgM27Xwd/aPuu8RfHEZPBzL1Z54okAHAQjXfcQNwvrlkAmAp4SlRTZ45vlthQ==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.23.6.tgz",
+			"integrity": "sha512-Z2uID7YJ7oNvAI20O9X0bblw7Qqs8Q2hFy0R9tAfnfLkp5MW0UH9eUvnDSnFwKZ0AvgS1ucqR4KzvVHgnke1VQ==",
 			"dev": true,
 			"bin": {
 				"parser": "bin/babel-parser.js"
@@ -1081,12 +1081,13 @@
 			}
 		},
 		"node_modules/@babel/plugin-transform-for-of": {
-			"version": "7.23.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.23.3.tgz",
-			"integrity": "sha512-X8jSm8X1CMwxmK878qsUGJRmbysKNbdpTv/O1/v0LuY/ZkZrng5WYiekYSdg9m09OTmDDUWeEDsTE+17WYbAZw==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-for-of/-/plugin-transform-for-of-7.23.6.tgz",
+			"integrity": "sha512-aYH4ytZ0qSuBbpfhuofbg/e96oQ7U2w1Aw/UQmKT+1l39uEhUPoFS3fHevDc1G0OvewyDudfMKY1OulczHzWIw==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-plugin-utils": "^7.22.5"
+				"@babel/helper-plugin-utils": "^7.22.5",
+				"@babel/helper-skip-transparent-expression-wrappers": "^7.22.5"
 			},
 			"engines": {
 				"node": ">=6.9.0"
@@ -1607,13 +1608,13 @@
 			}
 		},
 		"node_modules/@babel/preset-env": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.5.tgz",
-			"integrity": "sha512-0d/uxVD6tFGWXGDSfyMD1p2otoaKmu6+GD+NfAx0tMaH+dxORnp7T9TaVQ6mKyya7iBtCIVxHjWT7MuzzM9z+A==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/preset-env/-/preset-env-7.23.6.tgz",
+			"integrity": "sha512-2XPn/BqKkZCpzYhUUNZ1ssXw7DcXfKQEjv/uXZUXgaebCMYmkEsfZ2yY+vv+xtXv50WmL5SGhyB6/xsWxIvvOQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.23.5",
-				"@babel/helper-compilation-targets": "^7.22.15",
+				"@babel/helper-compilation-targets": "^7.23.6",
 				"@babel/helper-plugin-utils": "^7.22.5",
 				"@babel/helper-validator-option": "^7.23.5",
 				"@babel/plugin-bugfix-safari-id-destructuring-collision-in-function-expression": "^7.23.3",
@@ -1653,7 +1654,7 @@
 				"@babel/plugin-transform-dynamic-import": "^7.23.4",
 				"@babel/plugin-transform-exponentiation-operator": "^7.23.3",
 				"@babel/plugin-transform-export-namespace-from": "^7.23.4",
-				"@babel/plugin-transform-for-of": "^7.23.3",
+				"@babel/plugin-transform-for-of": "^7.23.6",
 				"@babel/plugin-transform-function-name": "^7.23.3",
 				"@babel/plugin-transform-json-strings": "^7.23.4",
 				"@babel/plugin-transform-literals": "^7.23.3",
@@ -1766,20 +1767,20 @@
 			}
 		},
 		"node_modules/@babel/traverse": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.5.tgz",
-			"integrity": "sha512-czx7Xy5a6sapWWRx61m1Ke1Ra4vczu1mCTtJam5zRTBOonfdJ+S/B6HYmGYu3fJtr8GGET3si6IhgWVBhJ/m8w==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.23.6.tgz",
+			"integrity": "sha512-czastdK1e8YByZqezMPFiZ8ahwVMh/ESl9vPgvgdB9AmFMGP5jfpFax74AQgl5zj4XHzqeYAg2l8PuUeRS1MgQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/code-frame": "^7.23.5",
-				"@babel/generator": "^7.23.5",
+				"@babel/generator": "^7.23.6",
 				"@babel/helper-environment-visitor": "^7.22.20",
 				"@babel/helper-function-name": "^7.23.0",
 				"@babel/helper-hoist-variables": "^7.22.5",
 				"@babel/helper-split-export-declaration": "^7.22.6",
-				"@babel/parser": "^7.23.5",
-				"@babel/types": "^7.23.5",
-				"debug": "^4.1.0",
+				"@babel/parser": "^7.23.6",
+				"@babel/types": "^7.23.6",
+				"debug": "^4.3.1",
 				"globals": "^11.1.0"
 			},
 			"engines": {
@@ -1787,9 +1788,9 @@
 			}
 		},
 		"node_modules/@babel/types": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.5.tgz",
-			"integrity": "sha512-ON5kSOJwVO6xXVRTvOI0eOnWe7VdUcIpsovGo9U/Br4Ie4UVFQTboO2cYnDhAGU6Fp+UxSiT+pMft0SMHfuq6w==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.23.6.tgz",
+			"integrity": "sha512-+uarb83brBzPKN38NX1MkB6vb6+mwvR6amUulqAE7ccQw1pEl+bCia9TbdG1lsnFP7lZySvUn37CHyXQdfTwzg==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-string-parser": "^7.23.4",
@@ -1837,9 +1838,9 @@
 			}
 		},
 		"node_modules/@eslint/eslintrc": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.3.tgz",
-			"integrity": "sha512-yZzuIG+jnVu6hNSzFEN07e8BxF3uAzYtQb6uDkaYZLo6oYZDCq454c5kB8zxnzfCYyP4MIuyBn10L0DqwujTmA==",
+			"version": "2.1.4",
+			"resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-2.1.4.tgz",
+			"integrity": "sha512-269Z39MS6wVJtsoUl10L60WdkhJVdPG24Q4eZTH3nnF6lpvSShEK3wQjDX9JRWAUPvPh7COouPpU9IrqaZFvtQ==",
 			"dev": true,
 			"dependencies": {
 				"ajv": "^6.12.4",
@@ -1866,9 +1867,9 @@
 			"dev": true
 		},
 		"node_modules/@eslint/eslintrc/node_modules/globals": {
-			"version": "13.23.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
-			"integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 			"dev": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
@@ -1905,9 +1906,9 @@
 			}
 		},
 		"node_modules/@eslint/js": {
-			"version": "8.54.0",
-			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.54.0.tgz",
-			"integrity": "sha512-ut5V+D+fOoWPgGGNj83GGjnntO39xDy6DWxO0wb7Jp3DcMX0TfIqdzHF85VTQkerdyGmuuMD9AKAo5KiNlf/AQ==",
+			"version": "8.55.0",
+			"resolved": "https://registry.npmjs.org/@eslint/js/-/js-8.55.0.tgz",
+			"integrity": "sha512-qQfo2mxH5yVom1kacMtZZJFVdW+E70mqHMJvVg6WTLo+VBuQJ4TojZlfWBjK0ve5BdEeNAVxOsl/nvNMpJOaJA==",
 			"dev": true,
 			"engines": {
 				"node": "^12.22.0 || ^14.17.0 || >=16.0.0"
@@ -2653,9 +2654,9 @@
 			"dev": true
 		},
 		"node_modules/browserslist": {
-			"version": "4.22.1",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.1.tgz",
-			"integrity": "sha512-FEVc202+2iuClEhZhrWy6ZiAcRLvNMyYcxZ8raemul1DYVOVdFsbqckWLdsixQZCpJlwe77Z3UTalE7jsjnKfQ==",
+			"version": "4.22.2",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.22.2.tgz",
+			"integrity": "sha512-0UgcrvQmBDvZHFGdYUehrCNIazki7/lUP3kkoi/r3YB2amZbFM9J43ZRkJTXBUZK4gmx56+Sqk9+Vs9mwZx9+A==",
 			"dev": true,
 			"funding": [
 				{
@@ -2672,9 +2673,9 @@
 				}
 			],
 			"dependencies": {
-				"caniuse-lite": "^1.0.30001541",
-				"electron-to-chromium": "^1.4.535",
-				"node-releases": "^2.0.13",
+				"caniuse-lite": "^1.0.30001565",
+				"electron-to-chromium": "^1.4.601",
+				"node-releases": "^2.0.14",
 				"update-browserslist-db": "^1.0.13"
 			},
 			"bin": {
@@ -3107,9 +3108,9 @@
 			}
 		},
 		"node_modules/electron-to-chromium": {
-			"version": "1.4.597",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.597.tgz",
-			"integrity": "sha512-0XOQNqHhg2YgRVRUrS4M4vWjFCFIP2ETXcXe/0KIQBjXE9Cpy+tgzzYfuq6HGai3hWq0YywtG+5XK8fyG08EjA==",
+			"version": "1.4.610",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.610.tgz",
+			"integrity": "sha512-mqi2oL1mfeHYtOdCxbPQYV/PL7YrQlxbvFEZ0Ee8GbDdShimqt2/S6z2RWqysuvlwdOrQdqvE0KZrBTipAeJzg==",
 			"dev": true
 		},
 		"node_modules/emoji-regex": {
@@ -3233,15 +3234,15 @@
 			}
 		},
 		"node_modules/eslint": {
-			"version": "8.54.0",
-			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.54.0.tgz",
-			"integrity": "sha512-NY0DfAkM8BIZDVl6PgSa1ttZbx3xHgJzSNJKYcQglem6CppHyMhRIQkBVSSMaSRnLhig3jsDbEzOjwCVt4AmmA==",
+			"version": "8.55.0",
+			"resolved": "https://registry.npmjs.org/eslint/-/eslint-8.55.0.tgz",
+			"integrity": "sha512-iyUUAM0PCKj5QpwGfmCAG9XXbZCWsqP/eWAWrG/W0umvjuLRBECwSFdt+rCntju0xEH7teIABPwXpahftIaTdA==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.2.0",
 				"@eslint-community/regexpp": "^4.6.1",
-				"@eslint/eslintrc": "^2.1.3",
-				"@eslint/js": "8.54.0",
+				"@eslint/eslintrc": "^2.1.4",
+				"@eslint/js": "8.55.0",
 				"@humanwhocodes/config-array": "^0.11.13",
 				"@humanwhocodes/module-importer": "^1.0.1",
 				"@nodelib/fs.walk": "^1.2.8",
@@ -5760,19 +5761,19 @@
 			}
 		},
 		"node_modules/node-releases": {
-			"version": "2.0.13",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.13.tgz",
-			"integrity": "sha512-uYr7J37ae/ORWdZeQ1xxMJe3NtdmqMC/JZK+geofDrkLUApKRHPd18/TxtBOJ4A0/+uUIliorNrfYV6s1b02eQ==",
+			"version": "2.0.14",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
+			"integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw==",
 			"dev": true
 		},
 		"node_modules/nodemon": {
-			"version": "3.0.1",
-			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.1.tgz",
-			"integrity": "sha512-g9AZ7HmkhQkqXkRc20w+ZfQ73cHLbE8hnPbtaFbFtCumZsjyMhKk9LajQ07U5Ux28lvFjZ5X7HvWR1xzU8jHVw==",
+			"version": "3.0.2",
+			"resolved": "https://registry.npmjs.org/nodemon/-/nodemon-3.0.2.tgz",
+			"integrity": "sha512-9qIN2LNTrEzpOPBaWHTm4Asy1LxXLSickZStAQ4IZe7zsoIpD/A7LWxhZV3t4Zu352uBcqVnRsDXSMR2Sc3lTA==",
 			"dev": true,
 			"dependencies": {
 				"chokidar": "^3.5.2",
-				"debug": "^3.2.7",
+				"debug": "^4",
 				"ignore-by-default": "^1.0.1",
 				"minimatch": "^3.1.2",
 				"pstree.remy": "^1.1.8",
@@ -5791,15 +5792,6 @@
 			"funding": {
 				"type": "opencollective",
 				"url": "https://opencollective.com/nodemon"
-			}
-		},
-		"node_modules/nodemon/node_modules/debug": {
-			"version": "3.2.7",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
-			"integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
-			"dev": true,
-			"dependencies": {
-				"ms": "^2.1.1"
 			}
 		},
 		"node_modules/nodemon/node_modules/lru-cache": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "@natlibfi/sru-client",
-	"version": "6.0.6",
+	"version": "6.0.7-alpha.1",
 	"lockfileVersion": 3,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "@natlibfi/sru-client",
-			"version": "6.0.6",
+			"version": "6.0.7-alpha.1",
 			"license": "LGPL-3.0+",
 			"dependencies": {
 				"debug": "^4.3.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,9 +16,9 @@
 			},
 			"devDependencies": {
 				"@babel/cli": "^7.23.4",
-				"@babel/core": "^7.23.5",
+				"@babel/core": "^7.23.6",
 				"@babel/node": "^7.22.19",
-				"@babel/preset-env": "^7.23.5",
+				"@babel/preset-env": "^7.23.6",
 				"@babel/register": "^7.22.15",
 				"@natlibfi/eslint-config-melinda-backend": "^3.0.3",
 				"@natlibfi/fixugen-http-client": "^3.0.2",
@@ -26,9 +26,9 @@
 				"babel-plugin-istanbul": "^6.1.1",
 				"chai": "^4.3.10",
 				"cross-env": "^7.0.3",
-				"eslint": "^8.54.0",
+				"eslint": "^8.55.0",
 				"mocha": "^10.2.0",
-				"nodemon": "^3.0.1",
+				"nodemon": "^3.0.2",
 				"nyc": "^15.1.0"
 			},
 			"engines": {
@@ -212,9 +212,9 @@
 			}
 		},
 		"node_modules/@babel/helper-create-class-features-plugin": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.5.tgz",
-			"integrity": "sha512-QELlRWxSpgdwdJzSJn4WAhKC+hvw/AtHbbrIoncKHkhKKR/luAlKkgBDcri1EzWAo8f8VvYVryEHN4tax/V67A==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.23.6.tgz",
+			"integrity": "sha512-cBXU1vZni/CpGF29iTu4YRbOZt3Wat6zCoMDxRF1MayiEc4URxOj31tT65HUM0CRpMowA3HCJaAOVOUnMf96cw==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-annotate-as-pure": "^7.22.5",
@@ -252,9 +252,9 @@
 			}
 		},
 		"node_modules/@babel/helper-define-polyfill-provider": {
-			"version": "0.4.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.3.tgz",
-			"integrity": "sha512-WBrLmuPP47n7PNwsZ57pqam6G/RGo1vw/87b0Blc53tZNGZ4x7YvZ6HgQe2vo1W/FR20OgjeZuGXzudPiXHFug==",
+			"version": "0.4.4",
+			"resolved": "https://registry.npmjs.org/@babel/helper-define-polyfill-provider/-/helper-define-polyfill-provider-0.4.4.tgz",
+			"integrity": "sha512-QcJMILQCu2jm5TFPGA3lCpJJTeEP+mqeXooG/NZbg/h5FTFi6V0+99ahlRsW8/kRLyb24LZVCCiclDedhLKcBA==",
 			"dev": true,
 			"dependencies": {
 				"@babel/helper-compilation-targets": "^7.22.6",
@@ -1741,9 +1741,9 @@
 			"dev": true
 		},
 		"node_modules/@babel/runtime": {
-			"version": "7.23.5",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.5.tgz",
-			"integrity": "sha512-NdUTHcPe4C99WxPub+K9l9tK5/lV4UXIoaHSYgzco9BCyjKAAwzdBI+wWtYqHt7LJdbo74ZjRPJgzVweq1sz0w==",
+			"version": "7.23.6",
+			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.23.6.tgz",
+			"integrity": "sha512-zHd0eUrf5GZoOWVCXp6koAKQTfZV07eit6bGPmJgnZdnSAvvZee6zniW2XMF7Cmc4ISOOnPy3QaSiIJGJkVEDQ==",
 			"dev": true,
 			"dependencies": {
 				"regenerator-runtime": "^0.14.0"
@@ -2137,13 +2137,13 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/scope-manager": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.13.1.tgz",
-			"integrity": "sha512-BW0kJ7ceiKi56GbT2KKzZzN+nDxzQK2DS6x0PiSMPjciPgd/JRQGMibyaN2cPt2cAvuoH0oNvn2fwonHI+4QUQ==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-6.14.0.tgz",
+			"integrity": "sha512-VT7CFWHbZipPncAZtuALr9y3EuzY1b1t1AEkIq2bTXUPKw+pHoXflGNG5L+Gv6nKul1cz1VH8fz16IThIU0tdg==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.13.1",
-				"@typescript-eslint/visitor-keys": "6.13.1"
+				"@typescript-eslint/types": "6.14.0",
+				"@typescript-eslint/visitor-keys": "6.14.0"
 			},
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -2154,13 +2154,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/type-utils": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.13.1.tgz",
-			"integrity": "sha512-A2qPlgpxx2v//3meMqQyB1qqTg1h1dJvzca7TugM3Yc2USDY+fsRBiojAEo92HO7f5hW5mjAUF6qobOPzlBCBQ==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-6.14.0.tgz",
+			"integrity": "sha512-x6OC9Q7HfYKqjnuNu5a7kffIYs3No30isapRBJl1iCHLitD8O0lFbRcVGiOcuyN837fqXzPZ1NS10maQzZMKqw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/typescript-estree": "6.13.1",
-				"@typescript-eslint/utils": "6.13.1",
+				"@typescript-eslint/typescript-estree": "6.14.0",
+				"@typescript-eslint/utils": "6.14.0",
 				"debug": "^4.3.4",
 				"ts-api-utils": "^1.0.1"
 			},
@@ -2181,9 +2181,9 @@
 			}
 		},
 		"node_modules/@typescript-eslint/types": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.13.1.tgz",
-			"integrity": "sha512-gjeEskSmiEKKFIbnhDXUyiqVma1gRCQNbVZ1C8q7Zjcxh3WZMbzWVfGE9rHfWd1msQtPS0BVD9Jz9jded44eKg==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-6.14.0.tgz",
+			"integrity": "sha512-uty9H2K4Xs8E47z3SnXEPRNDfsis8JO27amp2GNCnzGETEW3yTqEIVg5+AI7U276oGF/tw6ZA+UesxeQ104ceA==",
 			"dev": true,
 			"engines": {
 				"node": "^16.0.0 || >=18.0.0"
@@ -2194,13 +2194,13 @@
 			}
 		},
 		"node_modules/@typescript-eslint/typescript-estree": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.13.1.tgz",
-			"integrity": "sha512-sBLQsvOC0Q7LGcUHO5qpG1HxRgePbT6wwqOiGLpR8uOJvPJbfs0mW3jPA3ujsDvfiVwVlWUDESNXv44KtINkUQ==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-6.14.0.tgz",
+			"integrity": "sha512-yPkaLwK0yH2mZKFE/bXkPAkkFgOv15GJAUzgUVonAbv0Hr4PK/N2yaA/4XQbTZQdygiDkpt5DkxPELqHguNvyw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.13.1",
-				"@typescript-eslint/visitor-keys": "6.13.1",
+				"@typescript-eslint/types": "6.14.0",
+				"@typescript-eslint/visitor-keys": "6.14.0",
 				"debug": "^4.3.4",
 				"globby": "^11.1.0",
 				"is-glob": "^4.0.3",
@@ -2254,17 +2254,17 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/utils": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.13.1.tgz",
-			"integrity": "sha512-ouPn/zVoan92JgAegesTXDB/oUp6BP1v8WpfYcqh649ejNc9Qv+B4FF2Ff626kO1xg0wWwwG48lAJ4JuesgdOw==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-6.14.0.tgz",
+			"integrity": "sha512-XwRTnbvRr7Ey9a1NT6jqdKX8y/atWG+8fAIu3z73HSP8h06i3r/ClMhmaF/RGWGW1tHJEwij1uEg2GbEmPYvYg==",
 			"dev": true,
 			"dependencies": {
 				"@eslint-community/eslint-utils": "^4.4.0",
 				"@types/json-schema": "^7.0.12",
 				"@types/semver": "^7.5.0",
-				"@typescript-eslint/scope-manager": "6.13.1",
-				"@typescript-eslint/types": "6.13.1",
-				"@typescript-eslint/typescript-estree": "6.13.1",
+				"@typescript-eslint/scope-manager": "6.14.0",
+				"@typescript-eslint/types": "6.14.0",
+				"@typescript-eslint/typescript-estree": "6.14.0",
 				"semver": "^7.5.4"
 			},
 			"engines": {
@@ -2312,12 +2312,12 @@
 			"dev": true
 		},
 		"node_modules/@typescript-eslint/visitor-keys": {
-			"version": "6.13.1",
-			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.13.1.tgz",
-			"integrity": "sha512-NDhQUy2tg6XGNBGDRm1XybOHSia8mcXmlbKWoQP+nm1BIIMxa55shyJfZkHpEBN62KNPLrocSM2PdPcaLgDKMQ==",
+			"version": "6.14.0",
+			"resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-6.14.0.tgz",
+			"integrity": "sha512-fB5cw6GRhJUz03MrROVuj5Zm/Q+XWlVdIsFj+Zb1Hvqouc8t+XP2H5y53QYU/MGtd2dPg6/vJJlhoX3xc2ehfw==",
 			"dev": true,
 			"dependencies": {
-				"@typescript-eslint/types": "6.13.1",
+				"@typescript-eslint/types": "6.14.0",
 				"eslint-visitor-keys": "^3.4.1"
 			},
 			"engines": {
@@ -2572,13 +2572,13 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs2": {
-			"version": "0.4.6",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.6.tgz",
-			"integrity": "sha512-jhHiWVZIlnPbEUKSSNb9YoWcQGdlTLq7z1GHL4AjFxaoOUMuuEVJ+Y4pAaQUGOGk93YsVCKPbqbfw3m0SM6H8Q==",
+			"version": "0.4.7",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs2/-/babel-plugin-polyfill-corejs2-0.4.7.tgz",
+			"integrity": "sha512-LidDk/tEGDfuHW2DWh/Hgo4rmnw3cduK6ZkOI1NPFceSK3n/yAGeOsNT7FLnSGHkXj3RHGSEVkN3FsCTY6w2CQ==",
 			"dev": true,
 			"dependencies": {
 				"@babel/compat-data": "^7.22.6",
-				"@babel/helper-define-polyfill-provider": "^0.4.3",
+				"@babel/helper-define-polyfill-provider": "^0.4.4",
 				"semver": "^6.3.1"
 			},
 			"peerDependencies": {
@@ -2586,12 +2586,12 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-corejs3": {
-			"version": "0.8.6",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.6.tgz",
-			"integrity": "sha512-leDIc4l4tUgU7str5BWLS2h8q2N4Nf6lGZP6UrNDxdtfF2g69eJ5L0H7S8A5Ln/arfFAfHor5InAdZuIOwZdgQ==",
+			"version": "0.8.7",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-corejs3/-/babel-plugin-polyfill-corejs3-0.8.7.tgz",
+			"integrity": "sha512-KyDvZYxAzkC0Aj2dAPyDzi2Ym15e5JKZSK+maI7NAwSqofvuFglbSsxE7wUOvTg9oFVnHMzVzBKcqEb4PJgtOA==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.4.3",
+				"@babel/helper-define-polyfill-provider": "^0.4.4",
 				"core-js-compat": "^3.33.1"
 			},
 			"peerDependencies": {
@@ -2599,12 +2599,12 @@
 			}
 		},
 		"node_modules/babel-plugin-polyfill-regenerator": {
-			"version": "0.5.3",
-			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.3.tgz",
-			"integrity": "sha512-8sHeDOmXC8csczMrYEOf0UTNa4yE2SxV5JGeT/LP1n0OYVDUUFPxG9vdk2AlDlIit4t+Kf0xCtpgXPBwnn/9pw==",
+			"version": "0.5.4",
+			"resolved": "https://registry.npmjs.org/babel-plugin-polyfill-regenerator/-/babel-plugin-polyfill-regenerator-0.5.4.tgz",
+			"integrity": "sha512-S/x2iOCvDaCASLYsOOgWOq4bCfKYVqvO/uxjkaYyZ3rVsVE3CeAI/c84NpyuBBymEgNvHgjEot3a9/Z/kXvqsg==",
 			"dev": true,
 			"dependencies": {
-				"@babel/helper-define-polyfill-provider": "^0.4.3"
+				"@babel/helper-define-polyfill-provider": "^0.4.4"
 			},
 			"peerDependencies": {
 				"@babel/core": "^7.4.0 || ^8.0.0-0 <8.0.0"
@@ -2754,9 +2754,9 @@
 			}
 		},
 		"node_modules/caniuse-lite": {
-			"version": "1.0.30001565",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001565.tgz",
-			"integrity": "sha512-xrE//a3O7TP0vaJ8ikzkD2c2NgcVUvsEe2IvFTntV4Yd1Z9FVzh+gW+enX96L0psrbaFMcVcH2l90xNuGDWc8w==",
+			"version": "1.0.30001568",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001568.tgz",
+			"integrity": "sha512-vSUkH84HontZJ88MiNrOau1EBrCqEQYgkC5gIySiDlpsm8sGVrhU7Kx4V6h0tnqaHzIHZv08HlJIwPbL4XL9+A==",
 			"dev": true,
 			"funding": [
 				{
@@ -2921,9 +2921,9 @@
 			"dev": true
 		},
 		"node_modules/core-js": {
-			"version": "3.33.3",
-			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.33.3.tgz",
-			"integrity": "sha512-lo0kOocUlLKmm6kv/FswQL8zbkH7mVsLJ/FULClOhv8WRVmKLVcs6XPNQAzstfeJTCHMyButEwG+z1kHxHoDZw==",
+			"version": "3.34.0",
+			"resolved": "https://registry.npmjs.org/core-js/-/core-js-3.34.0.tgz",
+			"integrity": "sha512-aDdvlDder8QmY91H88GzNi9EtQi2TjvQhpCX6B1v/dAZHU1AuLgHvRh54RiOerpEhEW46Tkf+vgAViB/CWC0ag==",
 			"dev": true,
 			"hasInstallScript": true,
 			"funding": {
@@ -2932,12 +2932,12 @@
 			}
 		},
 		"node_modules/core-js-compat": {
-			"version": "3.33.3",
-			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.33.3.tgz",
-			"integrity": "sha512-cNzGqFsh3Ot+529GIXacjTJ7kegdt5fPXxCBVS1G0iaZpuo/tBz399ymceLJveQhFFZ8qThHiP3fzuoQjKN2ow==",
+			"version": "3.34.0",
+			"resolved": "https://registry.npmjs.org/core-js-compat/-/core-js-compat-3.34.0.tgz",
+			"integrity": "sha512-4ZIyeNbW/Cn1wkMMDy+mvrRUxrwFNjKwbhCfQpDd+eLgYipDqp8oGFGtLmhh18EDPKA0g3VUBYOxQGGwvWLVpA==",
 			"dev": true,
 			"dependencies": {
-				"browserslist": "^4.22.1"
+				"browserslist": "^4.22.2"
 			},
 			"funding": {
 				"type": "opencollective",
@@ -3659,9 +3659,9 @@
 			}
 		},
 		"node_modules/eslint/node_modules/globals": {
-			"version": "13.23.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-13.23.0.tgz",
-			"integrity": "sha512-XAmF0RjlrjY23MA51q3HltdlGxUpXPvg0GioKiD9X6HD28iMjo2dKC8Vqwm7lne4GNr78+RHTfliktR6ZH09wA==",
+			"version": "13.24.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-13.24.0.tgz",
+			"integrity": "sha512-AhO5QUcj8llrbG09iWhPU2B204J1xnPeL8kQmVorSsy+Sjj1sk8gIyh6cUocGmH4L0UuhAJy+hJMRA4mgA4mFQ==",
 			"dev": true,
 			"dependencies": {
 				"type-fest": "^0.20.2"
@@ -6075,13 +6075,13 @@
 			}
 		},
 		"node_modules/object.assign": {
-			"version": "4.1.4",
-			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.4.tgz",
-			"integrity": "sha512-1mxKf0e58bvyjSCtKYY4sRe9itRk3PJpquJOjeIkz885CczcI4IvJJDLPS72oowuSh+pBxUFROpX+TU++hxhZQ==",
+			"version": "4.1.5",
+			"resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.5.tgz",
+			"integrity": "sha512-byy+U7gp+FVwmyzKPYhW2h5l3crpmGsxl7X2s8y43IgxvG4g3QZ6CffDtsNQy1WsmZpQbO+ybo0AlW7TY6DcBQ==",
 			"dev": true,
 			"dependencies": {
-				"call-bind": "^1.0.2",
-				"define-properties": "^1.1.4",
+				"call-bind": "^1.0.5",
+				"define-properties": "^1.2.1",
 				"has-symbols": "^1.0.3",
 				"object-keys": "^1.1.1"
 			},
@@ -7227,9 +7227,9 @@
 			}
 		},
 		"node_modules/typescript": {
-			"version": "5.3.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
-			"integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
+			"version": "5.3.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.3.tgz",
+			"integrity": "sha512-pXWcraxM0uxAS+tN0AG/BF2TyqmHO014Z070UsJ+pFvYuRSq8KH8DmWpnbXe0pEPDHXZV3FcAbJkijJ5oNEnWw==",
 			"dev": true,
 			"peer": true,
 			"bin": {

--- a/package.json
+++ b/package.json
@@ -48,9 +48,9 @@
 	},
 	"devDependencies": {
 		"@babel/cli": "^7.23.4",
-		"@babel/core": "^7.23.5",
+		"@babel/core": "^7.23.6",
 		"@babel/node": "^7.22.19",
-		"@babel/preset-env": "^7.23.5",
+		"@babel/preset-env": "^7.23.6",
 		"@babel/register": "^7.22.15",
 		"@natlibfi/eslint-config-melinda-backend": "^3.0.3",
 		"@natlibfi/fixugen-http-client": "^3.0.2",
@@ -58,9 +58,9 @@
 		"babel-plugin-istanbul": "^6.1.1",
 		"chai": "^4.3.10",
 		"cross-env": "^7.0.3",
-		"eslint": "^8.54.0",
+		"eslint": "^8.55.0",
 		"mocha": "^10.2.0",
-		"nodemon": "^3.0.1",
+		"nodemon": "^3.0.2",
 		"nyc": "^15.1.0"
 	},
 	"eslintConfig": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
 		"url": "git@github.com:natlibfi/sru-client-js.git"
 	},
 	"license": "LGPL-3.0+",
-	"version": "6.0.6",
+	"version": "6.0.7-alpha.1",
 	"main": "dist/index.js",
 	"engines": {
 		"node": ">=18"


### PR DESCRIPTION
Bumps the development-dependencies group with 4 updates: [@babel/core](https://github.com/babel/babel/tree/HEAD/packages/babel-core), [@babel/preset-env](https://github.com/babel/babel/tree/HEAD/packages/babel-preset-env), [eslint](https://github.com/eslint/eslint) and [nodemon](https://github.com/remy/nodemon).


Updates `@babel/core` from 7.23.5 to 7.23.6
- [Release notes](https://github.com/babel/babel/releases)
- [Changelog](https://github.com/babel/babel/blob/main/CHANGELOG.md)
- [Commits](https://github.com/babel/babel/commits/v7.23.6/packages/babel-core)

Updates `@babel/preset-env` from 7.23.5 to 7.23.6
- [Release notes](https://github.com/babel/babel/releases)
- [Changelog](https://github.com/babel/babel/blob/main/CHANGELOG.md)
- [Commits](https://github.com/babel/babel/commits/v7.23.6/packages/babel-preset-env)

Updates `eslint` from 8.54.0 to 8.55.0
- [Release notes](https://github.com/eslint/eslint/releases)
- [Changelog](https://github.com/eslint/eslint/blob/main/CHANGELOG.md)
- [Commits](https://github.com/eslint/eslint/compare/v8.54.0...v8.55.0)

Updates `nodemon` from 3.0.1 to 3.0.2
- [Release notes](https://github.com/remy/nodemon/releases)
- [Commits](https://github.com/remy/nodemon/compare/v3.0.1...v3.0.2)

---
updated-dependencies:
- dependency-name: "@babel/core" dependency-type: direct:development update-type: version-update:semver-patch dependency-group: development-dependencies
- dependency-name: "@babel/preset-env" dependency-type: direct:development update-type: version-update:semver-patch dependency-group: development-dependencies
- dependency-name: eslint dependency-type: direct:development update-type: version-update:semver-minor dependency-group: development-dependencies
- dependency-name: nodemon dependency-type: direct:development update-type: version-update:semver-patch dependency-group: development-dependencies ...